### PR TITLE
Don't invoke 'mkParen' if you don't have to

### DIFF
--- a/plugin/RecordDotPreprocessor.hs
+++ b/plugin/RecordDotPreprocessor.hs
@@ -119,7 +119,8 @@ getFields DataDecl{tcdDataDefn=HsDataDefn{..}, ..} = concatMap ctor dd_cons
         field name (L _ ConDeclField{cd_fld_type=L _ ty, ..}) = [(result, name, fld, ty) | L _ fld <- cd_fld_names]
         field _ _ = error "unknown field declaration in getFields"
 
-        result = noL $ HsParTy noE $ foldl (\x y -> noL $ HsAppTy noE x $ hsLTyVarBndrToType y) (noL $ HsTyVar noE GHC.NotPromoted tcdLName) $ hsq_explicit tcdTyVars
+        -- A value of this data declaration will have this type.
+        result = foldl (\x y -> noL $ HsAppTy noE x $ hsLTyVarBndrToType y) (noL $ HsTyVar noE GHC.NotPromoted tcdLName) $ hsq_explicit tcdTyVars
 getFields _ = []
 
 
@@ -145,13 +146,15 @@ onExp (L o (SectionR _ mid@(isDot -> True) rhs))
     , srcSpanStart o == srcSpanStart (getLoc mid)
     , srcSpanEnd o == srcSpanEnd (getLoc rhs)
     , Just sels <- getSelectors rhs
-    = setL o $ mkParen $ foldl1 (\x y -> noL $ OpApp noE x (mkVar var_dot) y) $ map (mkVar var_getField `mkAppType`) $ reverse sels
+    -- Don't bracket here. The argument came in as a section so it's
+    -- already enclosed in brackets.
+    = setL o $ foldl1 (\x y -> noL $ OpApp noE x (mkVar var_dot) y) $ map (mkVar var_getField `mkAppType`) $ reverse sels
 
 -- Turn a{b=c, ...} into setField calls
 onExp (L o upd@RecordUpd{rupd_expr,rupd_flds=L _ (HsRecField (fmap rdrNameAmbiguousFieldOcc -> lbl) arg pun):flds})
     | let sel = mkSelector lbl
     , let arg2 = if pun then noL $ HsVar noE lbl else arg
-    , let expr = mkParen $ mkVar var_setField `mkAppType` sel `mkApp` mkParen rupd_expr `mkApp` arg2
+    , let expr = mkParen $ mkVar var_setField `mkAppType` sel `mkApp` rupd_expr `mkApp` arg2  -- 'rupd_expr' never needs bracketing.
     = onExp $ if null flds then expr else L o upd{rupd_expr=expr,rupd_flds=flds}
 
 onExp x = descend onExp x


### PR DESCRIPTION
Something a bit odd. This version reads,
```
    , let expr = mkParen $ mkVar var_setField `mkAppType` sel `mkApp` rupd_expr `mkApp` arg2  -- 'rupd_expr' never needs bracketing.
```
The DA version reads,
```
    , let expr = mkParen $ mkVar var_setField `mkAppType` sel `mkApp` arg2 `mkApp` rupd_expr -- 'rupd_expr' never needs bracketing.
```
(note the order of applications). Bug?

Check out  https://github.com/digital-asset/hlint/commit/e679bd34bb4e7783e1468f5988c22e71d0152e9e for an extension to hlint that taken together with this change means no record preprocessor code will generate redundant brackets warnings (I'd like to eliminate this patch in hlint but I haven't got the record preprocessor code quite worked out well enough to do that yet).

Also, in case it helps, here's a bunch of tests I fed ours today to gain confidence these changes are good.
```haskell
data A = A with x: Int deriving Eq
data B = B with y: A; z: A deriving Eq
data C = C {a : Int, b : Int} deriving Eq

main = scenario do

  f <- return $ \ x y z -> x {a = y, b = z}
  assert $ f C{a = 1, b = 2} 3 4 == C{a = 3, b = 4}
  f <- return $ \ x y z -> x {a = y + z}
  assert $ f C{a = 1, b = 2} 1 2 == C{a = 3, b = 2}
  f <- return $ \ x a -> B a with x a with x
  assert $ f 1 A{x = 12} == B (A 1) (A 1)
  f <- return $ \ a -> a {x = a.x + 1}
  assert $ (f A{x = 1}).x == 2
  f <- return $ \b -> b {y = b.y, z = b.z{x = 4}}
  assert $ (f B{y = A{x = 1}, z = A{x = 2}}).z.x == 4
  assert $ let res = f B{y = A{x = 1}, z = A{x = 2}} in res.z.x == 4
  f <- return $ \b -> b {y = b.y, z = b.z{x = (\ x -> x * x) b.z.x}}
  assert $ (f B{y = A{x = 1}, z = A{x = 2}}).z.x == 4
  f <- return $ \b -> b {y = b.y{x = b.y.x + 1}, z = b.z{x = (\ x -> x * x) b.z{x = b.z.x}.x}}
  assert $ (f B{y = A{x = 1}, z = A{x = 2}}).y.x == 2
  assert $ (f B{y = A{x = 1}, z = A{x = 2}}).z.x == 4

  f <- return $ \ l -> map (.x) l
  assert $ f [A 1, A 2, A 3] == [1, 2, 3]
  f <- return $ \ l -> map (.y.x) l
  assert $ f [B (A 1) (A 2), B (A 2) (A 3), B (A 3) (A 4)] == [1, 2, 3]
```