### PR TITLE
Re-export preprocessor internals as library

### DIFF
--- a/plugin/RecordDotPreprocessor/Lib.hs
+++ b/plugin/RecordDotPreprocessor/Lib.hs
@@ -1,0 +1,12 @@
+module RecordDotPreprocessor.Lib (module X, runPreprocessStr) where 
+
+import Edit as X (edit, editLoop)
+import Lexer as X
+import Paren as X
+
+runPreprocessStr :: String -> String
+runPreprocessStr input =
+    unlexerFile Nothing $ unparens $ editLoop $ paren $ lexer input
+    where
+        paren = parenOn lexeme [("(",")"),("[","]"),("{","}"),("`","`")]
+

--- a/plugin/RecordDotPreprocessor/Lib.hs
+++ b/plugin/RecordDotPreprocessor/Lib.hs
@@ -6,7 +6,5 @@ import Paren as X
 
 runPreprocessStr :: String -> String
 runPreprocessStr input =
-    unlexerFile Nothing $ unparens $ editLoop $ paren $ lexer input
-    where
-        paren = parenOn lexeme [("(",")"),("[","]"),("{","}"),("`","`")]
+    unlexerFile Nothing $ unparens $ editLoop $ parens $ lexer input
 

--- a/plugin/RecordDotPreprocessor/Lib.hs
+++ b/plugin/RecordDotPreprocessor/Lib.hs
@@ -1,10 +1,3 @@
-module RecordDotPreprocessor.Lib (module X, runPreprocessStr) where 
+module RecordDotPreprocessor.Lib (module X) where
 
-import Edit as X (edit, editLoop)
-import Lexer as X
-import Paren as X
-
-runPreprocessStr :: String -> String
-runPreprocessStr input =
-    unlexerFile Nothing $ unparens $ editLoop $ parens $ lexer input
-
+import Edit as X

--- a/preprocessor/Edit.hs
+++ b/preprocessor/Edit.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
 
-module Edit(edit, editLoop) where
+module Edit(recordDotPreprocessor, recordDotPreprocessorOnFragment) where
 
 import Lexer
 import Paren
@@ -9,9 +9,14 @@ import Data.Char
 import Data.List.Extra
 import Control.Monad.Extra
 
+recordDotPreprocessor :: FilePath -> String -> String
+recordDotPreprocessor original = unlexerFile (Just original) . unparens . edit . parens . lexer
+    where
+        edit :: [PL] -> [PL]
+        edit = editAddPreamble . editAddInstances . editLoop
 
-edit :: [PL] -> [PL]
-edit = editAddPreamble . editAddInstances . editLoop
+recordDotPreprocessorOnFragment :: String -> String
+recordDotPreprocessorOnFragment = unlexerFile Nothing . unparens . editLoop . parens . lexer
 
 
 ---------------------------------------------------------------------

--- a/preprocessor/Edit.hs
+++ b/preprocessor/Edit.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
 
-module Edit(edit) where
+module Edit(edit, editLoop) where
 
 import Lexer
 import Paren

--- a/preprocessor/Lexer.hs
+++ b/preprocessor/Lexer.hs
@@ -96,7 +96,7 @@ lexerWhitespace xs = ([], xs)
 seen xs = first (xs++)
 
 
-unlexerFile :: FilePath -> [Lexeme] -> String
+unlexerFile :: Maybe FilePath -> [Lexeme] -> String
 unlexerFile src xs =
     dropping 1 ++
     -- we split the whitespace up to increase the chances of startLine being true below
@@ -122,4 +122,6 @@ unlexerFile src xs =
         go _ _ [] = ""
 
         -- write out a line marker with a trailing newline
-        dropping n = "{-# LINE " ++ show n ++ " " ++ show src ++ " #-}\n"
+        dropping n = case src of
+          Just src' -> "{-# LINE " ++ show n ++ " " ++ show src' ++ " #-}\n"
+          Nothing -> ""

--- a/preprocessor/Paren.hs
+++ b/preprocessor/Paren.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE ScopedTypeVariables, DeriveFunctor #-}
 
 -- Most of this module follows the Haskell report, https://www.haskell.org/onlinereport/lexemes.html
-module Paren(Paren(..), parenOn, unparen, unparens) where
+module Paren(Paren(..), parens, unparens) where
 
 import Data.Tuple.Extra
+import Lexer(Lexeme(..))
 
 -- | A list of items which are paranthesised.
 data Paren a
@@ -26,6 +27,8 @@ parenOn proj pairs = fst . go Nothing
         go close (x:xs) = first (Item x :) $ go close xs
         go close [] = ([], Nothing)
 
+parens :: [Lexeme] -> [Paren Lexeme]
+parens = parenOn lexeme [("(",")"),("[","]"),("{","}"),("`","`")]
 
 unparens :: [Paren a] -> [a]
 unparens = concatMap unparen

--- a/preprocessor/Preprocessor.hs
+++ b/preprocessor/Preprocessor.hs
@@ -23,6 +23,5 @@ main = do
 
 runConvert :: FilePath -> FilePath -> FilePath -> IO ()
 runConvert original input output = do
-    res <- unlexerFile (Just original) . unparens . edit . paren . lexer <$> readFileUTF8' input
+    res <- unlexerFile (Just original) . unparens . edit . parens . lexer <$> readFileUTF8' input
     if output == "-" then putStrLn res else writeFileUTF8 output res
-    where paren = parenOn lexeme [("(",")"),("[","]"),("{","}"),("`","`")]

--- a/preprocessor/Preprocessor.hs
+++ b/preprocessor/Preprocessor.hs
@@ -1,8 +1,6 @@
 
 module Preprocessor(main) where
 
-import Lexer
-import Paren
 import Edit
 import System.IO.Extra
 import System.Environment
@@ -23,5 +21,5 @@ main = do
 
 runConvert :: FilePath -> FilePath -> FilePath -> IO ()
 runConvert original input output = do
-    res <- unlexerFile (Just original) . unparens . edit . parens . lexer <$> readFileUTF8' input
+    res <- recordDotPreprocessor original <$> readFileUTF8' input
     if output == "-" then putStrLn res else writeFileUTF8 output res

--- a/preprocessor/Preprocessor.hs
+++ b/preprocessor/Preprocessor.hs
@@ -23,6 +23,6 @@ main = do
 
 runConvert :: FilePath -> FilePath -> FilePath -> IO ()
 runConvert original input output = do
-    res <- unlexerFile original . unparens . edit . paren . lexer <$> readFileUTF8' input
+    res <- unlexerFile (Just original) . unparens . edit . paren . lexer <$> readFileUTF8' input
     if output == "-" then putStrLn res else writeFileUTF8 output res
     where paren = parenOn lexeme [("(",")"),("[","]"),("{","}"),("`","`")]

--- a/record-dot-preprocessor.cabal
+++ b/record-dot-preprocessor.cabal
@@ -32,7 +32,9 @@ source-repository head
 
 library
     default-language:   Haskell2010
-    hs-source-dirs:     plugin
+    hs-source-dirs:
+        plugin
+        preprocessor
     build-depends:
         base >= 4.8 && < 5,
         uniplate,
@@ -42,8 +44,12 @@ library
         buildable: False
     exposed-modules:
         RecordDotPreprocessor
+        RecordDotPreprocessor.Lib
     other-modules:
         Compat
+        Edit
+        Lexer
+        Paren
 
 executable record-dot-preprocessor
     default-language:   Haskell2010


### PR DESCRIPTION
We was needed to use preprocessor  inside custom quasi-quotes, so I add RecordDotPreprocessor.Lib module, which re-export guts of preprocessor into same library where plugin resides. I tried to make changes minimal as possible.

If you can suggest other way to access to preprocessor code as a library (without copying code) -- your suggestions are welcomed.