### PR TITLE
Do not derive HasField for fields with existential types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         # and not in CI - so exclude it
         include:
         - os: macOS-latest
+          ghc: "8.10"
 
     steps:
     - run: git config --global core.autocrlf false

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright Neil Mitchell 2018-2021.
+Copyright Neil Mitchell 2018-2022.
 
 Licensed under either of:
 

--- a/examples/Both.hs
+++ b/examples/Both.hs
@@ -217,6 +217,16 @@ type family C (f :: T.Type -> T.Type) (a :: T.Type) :: T.Type where
     C (Nullable c) a = C c (Maybe a)
     C f a = f a
 
+-- Existential typed field xc' need to be omitted from types, otherwise
+-- compiler produce following error:
+--    • Illegal instance declaration for
+--        ‘GHC.Records.Extra.HasField "xc'" (Existential a) aplg’
+--        The liberal coverage condition fails in class ‘GHC.Records.Extra.HasField’
+--          for functional dependency: ‘x r -> a’
+--        Reason: lhs types ‘"xc'"’, ‘Existential a’
+--          do not jointly determine rhs type ‘aplg’
+--        Un-determined variable: aplg
+data Existential a = forall b. Bar { xa :: a, xb :: !a, xc' :: b }
 
 data Foo9 f = Foo9 {
   bar :: C f Int,

--- a/examples/Both.hs
+++ b/examples/Both.hs
@@ -2,6 +2,8 @@
 
 {-# OPTIONS_GHC -Werror -Wall -Wno-type-defaults -Wno-partial-type-signatures -Wincomplete-record-updates -Wno-unused-top-binds #-} -- can we produce -Wall clean code
 {-# LANGUAGE PartialTypeSignatures, GADTs, StandaloneDeriving, DataKinds, KindSignatures #-} -- also tests we put language extensions before imports
+-- 8.8+ doesn't need it to be set explicitly
+{-# LANGUAGE ExistentialQuantification #-}
 
 import Control.Exception
 import Data.Version

--- a/plugin/Compat.hs
+++ b/plugin/Compat.hs
@@ -157,6 +157,7 @@ dropRnTraceFlags = id
 
 freeTyVars :: PluginEnv => LHsType GhcPs -> [Located RdrName]
 #if __GLASGOW_HASKELL__ < 808
+{-# NOINLINE freeTyVars #-}
 freeTyVars  = freeKiTyVarsAllVars . runRnM . extractHsTyRdrTyVars
   where
     runRnM :: RnM a -> a

--- a/plugin/Compat.hs
+++ b/plugin/Compat.hs
@@ -8,10 +8,12 @@ import GHC
 #if __GLASGOW_HASKELL__ < 900
 import BasicTypes
 import TcEvidence
+import RnTypes as Compat
 #else
 import GHC.Types.Basic
 import GHC.Unit.Types
 import GHC.Parser.Annotation
+import GHC.Rename.HsType as Compat
 #endif
 #if __GLASGOW_HASKELL__ < 810
 import HsSyn as Compat
@@ -130,4 +132,9 @@ qualifiedImplicitImport x = noL $ ImportDecl noE NoSourceText (noL x) Nothing Fa
 qualifiedImplicitImport x = noL $ ImportDecl noE NoSourceText (noL x) Nothing NotBoot False
     QualifiedPost {- qualified -} True {- implicit -} Nothing Nothing
 
+#endif
+#if __GLASGOW_HASKELL__ < 900
+freeTyVars = freeKiTyVarsAllVars . extractHsTyRdrTyVars
+#else
+freeTyVars = extractHsTyRdrTyVars
 #endif

--- a/plugin/Compat.hs
+++ b/plugin/Compat.hs
@@ -133,7 +133,8 @@ qualifiedImplicitImport x = noL $ ImportDecl noE NoSourceText (noL x) Nothing No
     QualifiedPost {- qualified -} True {- implicit -} Nothing Nothing
 
 #endif
-#if __GLASGOW_HASKELL__ < 900
+
+#if __GLASGOW_HASKELL__ < 810
 freeTyVars = freeKiTyVarsAllVars . extractHsTyRdrTyVars
 #else
 freeTyVars = extractHsTyRdrTyVars

--- a/plugin/Compat.hs
+++ b/plugin/Compat.hs
@@ -28,6 +28,8 @@ import Data.IORef as Compat
 import TcRnTypes
 import IOEnv
 import UniqSupply
+import DynFlags
+import HscTypes
 #endif
 
 ---------------------------------------------------------------------
@@ -145,6 +147,10 @@ qualifiedImplicitImport x = noL $ ImportDecl noE NoSourceText (noL x) Nothing No
 
 #if __GLASGOW_HASKELL__ < 808
 type PluginEnv = (?hscenv :: HscEnv, ?uniqSupply :: IORef UniqSupply)
+
+dropRnTraceFlags :: HscEnv -> HscEnv
+dropRnTraceFlags env@HscEnv{hsc_dflags = dflags} =  env{hsc_dflags = dopt_unset dflags Opt_D_dump_rn_trace}
+
 #else
 type PluginEnv = ()
 #endif

--- a/plugin/Compat.hs
+++ b/plugin/Compat.hs
@@ -11,11 +11,13 @@ import GHC
 import BasicTypes
 import TcEvidence
 import RnTypes as Compat
+import UniqSupply
 #else
 import GHC.Types.Basic
 import GHC.Unit.Types
 import GHC.Parser.Annotation
 import GHC.Rename.HsType as Compat
+import GHC.Types.Unique.Supply
 #endif
 #if __GLASGOW_HASKELL__ < 810
 import HsSyn as Compat
@@ -24,13 +26,12 @@ import GHC.Hs as Compat
 #endif
 #if __GLASGOW_HASKELL__ < 808
 import System.IO.Unsafe as Compat (unsafePerformIO)
-import Data.IORef as Compat
 import TcRnTypes
 import IOEnv
-import UniqSupply
 import DynFlags
 import HscTypes
 #endif
+import Data.IORef as Compat
 
 ---------------------------------------------------------------------
 -- UTILITIES
@@ -145,14 +146,13 @@ qualifiedImplicitImport x = noL $ ImportDecl noE NoSourceText (noL x) Nothing No
 
 #endif
 
-#if __GLASGOW_HASKELL__ < 808
 type PluginEnv = (?hscenv :: HscEnv, ?uniqSupply :: IORef UniqSupply)
 
 dropRnTraceFlags :: HscEnv -> HscEnv
+#if __GLASGOW_HASKELL__ < 808
 dropRnTraceFlags env@HscEnv{hsc_dflags = dflags} =  env{hsc_dflags = dopt_unset dflags Opt_D_dump_rn_trace}
-
 #else
-type PluginEnv = ()
+dropRnTraceFlags = id
 #endif
 
 freeTyVars :: PluginEnv => LHsType GhcPs -> [Located RdrName]

--- a/plugin/RecordDotPreprocessor.hs
+++ b/plugin/RecordDotPreprocessor.hs
@@ -21,6 +21,7 @@ import SrcLoc
 import GHC.Data.Bag
 import qualified GHC.Driver.Plugins as GHC
 import qualified GHC.Driver.Types as GHC
+import qualified GHC.Driver.Main as HscMain
 import qualified GHC.Builtin.Names as GHC
 import qualified GHC.Plugins as GHC
 import GHC.Types.SrcLoc

--- a/plugin/RecordDotPreprocessor.hs
+++ b/plugin/RecordDotPreprocessor.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards, ViewPatterns, NamedFieldPuns, OverloadedStrings, LambdaCase #-}
-{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE ImplicitParams, ScopedTypeVariables #-}
 {- HLINT ignore "Use camelCase" -}
 
 -- | Module containing the plugin.
@@ -37,7 +37,7 @@ plugin = GHC.defaultPlugin
     where
         parsedResultAction _cliOptions _modSummary x = do
 #if __GLASGOW_HASKELL__ < 900
-            hscenv <- GHC.Hsc (\env w -> pure (env, w))
+            hscenv <- GHC.Hsc (\env w -> pure (dropRnTraceFlags env, w))
             uniqSupply <- GHC.liftIO (GHC.mkSplitUniqSupply '0')
             uniqSupplyRef <- GHC.liftIO $ newIORef uniqSupply
             let ?hscenv = hscenv

--- a/plugin/RecordDotPreprocessor.hs
+++ b/plugin/RecordDotPreprocessor.hs
@@ -139,15 +139,15 @@ conClosedFields resultVars = \case
     ConDeclH98 {con_args = RecCon (L _ args), con_name, con_ex_tvs} ->
         [ (unLoc con_name, unLoc name, unLoc ty)
             | ConDeclField {cd_fld_names, cd_fld_type = ty} <- universeBi args,
-                name <- cd_fld_names,
-                null (freeTyVars' ty \\ resultVars)
+                null (freeTyVars' ty \\ resultVars),
+                name <- cd_fld_names
         ]
     ConDeclGADT {con_args = RecCon (L _ args), con_res_ty, con_names} ->
          [ (unLoc con_name, unLoc name, unLoc ty)
          | ConDeclField {cd_fld_names, cd_fld_type = ty} <- universeBi args,
+             null (freeTyVars ty \\ freeTyVars con_res_ty),
              name <- cd_fld_names,
-             con_name <- con_names,
-             null (freeTyVars ty \\ freeTyVars con_res_ty)
+             con_name <- con_names
          ]
     _ -> []
     where

--- a/plugin/RecordDotPreprocessor.hs
+++ b/plugin/RecordDotPreprocessor.hs
@@ -37,13 +37,11 @@ plugin = GHC.defaultPlugin
     }
     where
         parsedResultAction _cliOptions _modSummary x = do
-#if __GLASGOW_HASKELL__ < 808 
-            hscenv <- dropRnTraceFlags <$> HscMain.getHscEnv 
+            hscenv <- dropRnTraceFlags <$> HscMain.getHscEnv
             uniqSupply <- GHC.liftIO (GHC.mkSplitUniqSupply '0')
             uniqSupplyRef <- GHC.liftIO $ newIORef uniqSupply
             let ?hscenv = hscenv
             let ?uniqSupply = uniqSupplyRef
-#endif
             pure x{GHC.hpm_module = onModule <$> GHC.hpm_module x}
 
 

--- a/plugin/RecordDotPreprocessor.hs
+++ b/plugin/RecordDotPreprocessor.hs
@@ -14,6 +14,7 @@ import qualified GHC
 #if __GLASGOW_HASKELL__ < 900
 import Bag
 import qualified GhcPlugins as GHC
+import qualified HscMain
 import qualified PrelNames as GHC
 import SrcLoc
 #else
@@ -36,8 +37,8 @@ plugin = GHC.defaultPlugin
     }
     where
         parsedResultAction _cliOptions _modSummary x = do
-#if __GLASGOW_HASKELL__ < 900
-            hscenv <- GHC.Hsc (\env w -> pure (dropRnTraceFlags env, w))
+#if __GLASGOW_HASKELL__ < 808 
+            hscenv <- dropRnTraceFlags <$> HscMain.getHscEnv 
             uniqSupply <- GHC.liftIO (GHC.mkSplitUniqSupply '0')
             uniqSupplyRef <- GHC.liftIO $ newIORef uniqSupply
             let ?hscenv = hscenv

--- a/record-dot-preprocessor.cabal
+++ b/record-dot-preprocessor.cabal
@@ -8,7 +8,7 @@ license-file:       LICENSE
 category:           Development
 author:             Neil Mitchell <ndmitchell@gmail.com>
 maintainer:         Neil Mitchell <ndmitchell@gmail.com>
-copyright:          Neil Mitchell 2018-2021
+copyright:          Neil Mitchell 2018-2022
 synopsis:           Preprocessor to allow record.field syntax
 description:
     In almost every programming language @a.b@ will get the @b@ field from the @a@ data type, and many different data types can have a @b@ field.

--- a/test/PluginExample.hs
+++ b/test/PluginExample.hs
@@ -20,6 +20,11 @@ main = pure ()
 -- things that are now treated as comments
 {-# OPTIONS_GHC -Werror -Wall -Wno-type-defaults -Wno-partial-type-signatures -Wno-incomplete-record-updates -Wno-unused-top-binds #-}
 {-# LANGUAGE PartialTypeSignatures, GADTs, StandaloneDeriving, KindSignatures #-}
+#if __GLASGOW_HASKELL__ < 808
+-- 8.8+ doesn't need it to be set explicitly
+{-# LANGUAGE ExistentialQuantification #-}
+#endif
+
 module PluginExample where
 #include "../examples/Both.hs"
 


### PR DESCRIPTION
Compiler fails on declarations like:

```haskell
    data Existential a = forall b. Bar { xa :: a, xb :: !a, xc' :: b }
```
    
where impossible to yield instance for ``xc'`` 7 field.

```    
    test/PluginExample.hs:1:1: error:
        • Illegal instance declaration for
            ‘GHC.Records.Extra.HasField "xc'" (Existential a) aplg’
            The liberal coverage condition fails in class ‘GHC.Records.Extra.HasField’
              for functional dependency: ‘x r -> a’
            Reason: lhs types ‘"xc'"’, ‘Existential a’
              do not jointly determine rhs type ‘aplg’
            Un-determined variable: aplg
        • In the instance declaration for
            ‘GHC.Records.Extra.HasField "xc'" (Existential a) aplg’
```

Idea and prototype by @kana-sama, with some refinements and testing from me.
We tested in with GHC 8.8.4 on large code base, but I tried to keep compatibility with GHC 9 as well