### PR TITLE
ghc-9.2 compatibility

### DIFF
--- a/record-dot-preprocessor.cabal
+++ b/record-dot-preprocessor.cabal
@@ -38,10 +38,8 @@ library
     build-depends:
         base >= 4.8 && < 5,
         uniplate,
-        ghc,
+        ghc >=8.6 && <9.3,
         extra
-    if impl(ghc < 8.6)
-        buildable: False
     exposed-modules:
         RecordDotPreprocessor
         RecordDotPreprocessor.Lib

--- a/test/PluginExample.hs
+++ b/test/PluginExample.hs
@@ -19,6 +19,9 @@ main = pure ()
 {-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances, TypeFamilies, TypeOperators, GADTs, UndecidableInstances #-}
 -- things that are now treated as comments
 {-# OPTIONS_GHC -Werror -Wall -Wno-type-defaults -Wno-partial-type-signatures -Wno-incomplete-record-updates -Wno-unused-top-binds #-}
+#if __GLASGOW_HASKELL__ >=902
+{-# OPTIONS_GHC -Wno-ambiguous-fields #-}
+#endif
 {-# LANGUAGE PartialTypeSignatures, GADTs, StandaloneDeriving, KindSignatures #-}
 #if __GLASGOW_HASKELL__ < 808
 -- 8.8+ doesn't need it to be set explicitly


### PR DESCRIPTION
This PR adds GHC 9.2 compatibility for the record-dot-preprocessor plugin. It's still WIP as it's not fully backwards compatible yet.