### PR TITLE
Fix unreachable exit condition for nested block comments

### DIFF
--- a/preprocessor/Lexer.hs
+++ b/preprocessor/Lexer.hs
@@ -88,6 +88,7 @@ lexerWhitespace ('-':'-':xs)
 lexerWhitespace ('{':'-':xs) = seen "{-" $ f 1 xs
     where
         f 1 ('-':'}':xs) = seen "-}" $ lexerWhitespace xs
+        f i ('-':'}':xs) = seen "-}" $ f (i-1) xs
         f i ('{':'-':xs) = seen "{-" $ f (i+1) xs
         f i (x:xs) = seen [x] $ f i xs
         f i [] = ([], [])


### PR DESCRIPTION
In `lexerWhitespace`, `i` increments with each nested block comment, but it does not decrement when the nested block comment terminates. `f 1 ('-':'}':xs)` therefore becomes unreachable for any nested block comments, because `i` can never decrement to `1` after reaching `2`, which results in the rest of the file being lexed as a comment. This PR fixes that.