### PR TITLE
Fix lexer cursor repositioning

### DIFF
--- a/preprocessor/Lexer.hs
+++ b/preprocessor/Lexer.hs
@@ -40,7 +40,7 @@ lexer = go1 1 1
         go line col xs
             | (lexeme, xs) <- lexerLexeme xs
             , (whitespace, xs) <- lexerWhitespace xs
-            , (line2, col2) <- reposition line col $ whitespace ++ lexeme
+            , (line2, col2) <- reposition line col $ lexeme ++ whitespace
             = Lexeme{..} : go line2 col2 xs
 
 


### PR DESCRIPTION
`lexeme ++ whitespace` was in the wrong order. This matters because any newline characters in either `lexeme` or`whitespace` will reset the column number in `reposition`. Therefore the two strings must be concatenated in the same order in which they where lexed, otherwise newlines in the `whitespace` portion won't reset the column correctly.

I don't know if this matters for `record-dot-preprocessor`, but I was working on an indentation aware fork of this repo where this caused issues that took time to track down.