### PR TITLE
Skipping polymorphic fields with forall (WIP)

### DIFF
--- a/plugin/Compat.hs
+++ b/plugin/Compat.hs
@@ -31,6 +31,7 @@ import GHC.Types.Unique.Supply
 #endif
 #if __GLASGOW_HASKELL__ < 810
 import HsSyn as Compat
+import HsTypes as Compat
 #else
 import GHC.Hs as Compat
 #endif

--- a/plugin/RecordDotPreprocessor.hs
+++ b/plugin/RecordDotPreprocessor.hs
@@ -172,6 +172,7 @@ conClosedFields resultVars = \case
         [ (unLoc con_name, unLoc name, unLoc ty)
             | ConDeclField {cd_fld_names, cd_fld_type = ty} <- universeBi args,
                 null (freeTyVars' ty \\ resultVars),
+                not $ isLHsForAllTy ty,
                 name <- cd_fld_names
         ]
 #if __GLASGOW_HASKELL__ >= 901

--- a/test/PluginExample.hs
+++ b/test/PluginExample.hs
@@ -16,7 +16,7 @@ main = pure ()
 #else
 
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
-{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances, TypeFamilies, TypeOperators, GADTs, UndecidableInstances #-}
+{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances, TypeFamilies, TypeOperators, GADTs, UndecidableInstances, RankNTypes #-}
 -- things that are now treated as comments
 {-# OPTIONS_GHC -Werror -Wall -Wno-type-defaults -Wno-partial-type-signatures -Wno-incomplete-record-updates -Wno-unused-top-binds #-}
 #if __GLASGOW_HASKELL__ >=902
@@ -28,7 +28,14 @@ main = pure ()
 {-# LANGUAGE ExistentialQuantification #-}
 #endif
 
+{-# LANGUAGE RankNTypes #-}
 module PluginExample where
 #include "../examples/Both.hs"
+
+data PolyField = PolyField
+    { polyField :: forall a. a -> IO ()
+    }
+
+
 
 #endif


### PR DESCRIPTION
Polymorphic fields cause a problems:
```haskell
data PolyField = PolyField
    { polyField :: forall a. a -> IO ()
    }
```
produce following error
```
test/PluginExample.hs:1:1: error:
    • Illegal polymorphic type: forall a. a -> IO ()
      GHC doesn't yet support impredicative polymorphism
    • In the instance declaration for
        ‘GHC.Records.Extra.HasField "polyField" PolyField aplg’
```

I managed to solve it for non-GADTs syntax, and GHC 8.8 (and only for plugin at the moment) -- as a PoC.  I extended skipping existentials, and also skip fields with `forall` statement in field type. One issue with it, that only GHC 8.8 have isLHsForAllTy function. 
I'll try to backport this function into `Compat` as solution.
(support GADTs syntax is trivial, just test need to be added)

Second problem -- I haven't idea what to do with _preprocessor_, my solution works only for plugin.

I made this PR early, to get some guidance, while I polishing it.